### PR TITLE
Locally aware week start

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,7 @@ const DateRangePicker = ({
     function populateHeaders() {
       let _dayHeaders = [];
       for (let i = 0; i <= 6; ++i) {
-        let day = _moment(displayedDate).day(i).format("dddd").substr(0, 2);
+        let day = _moment(displayedDate).weekday(i).format("dddd").substr(0, 2);
         _dayHeaders.push(
           <Header
             key={`dayHeader-${i}`}
@@ -222,7 +222,7 @@ const DateRangePicker = ({
       let week = [];
       let daysInMonth = displayedDate.daysInMonth();
       let startOfMonth = _moment(displayedDate).set("date", 1);
-      let offset = startOfMonth.day();
+      let offset = startOfMonth.weekday();
       week = week.concat(
         Array.from({ length: offset }, (x, i) => (
           <Day empty key={"empty-" + i} />


### PR DESCRIPTION
It's better do use weekday() instead of day() to get the week day. This lets the calendar begin on Monday, Sunday or any other day depending on the moment locale. E.g. in Germany it's normal to have the calendar start on Monday, a calendar starting on Sunday is unusual to us. 

Overall great work and thanks!