### PR TITLE
add childrenContainerStyle prop to be able to style the children container View

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ const DateRangePicker = ({
   buttonStyle,
   buttonTextStyle,
   presetButtons,
+  childrenContainerStyle
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [weeks, setWeeks] = useState([]);
@@ -80,6 +81,11 @@ const DateRangePicker = ({
     monthButtons: {
       ...styles.monthButtons,
       ...monthButtonsStyle,
+    },
+    childrenContainer: 
+    {
+      ...styles.childrenContainer,
+      ...childrenContainerStyle,
     },
   };
 
@@ -294,7 +300,7 @@ const DateRangePicker = ({
   ]);
 
   const node = (
-    <View>
+    <View style={mergedStyles.childrenContainer}>
       <TouchableWithoutFeedback onPress={onOpen}>
         {children ? (
           children
@@ -484,4 +490,6 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
   },
+  childrenContainer: {
+  }
 });


### PR DESCRIPTION
To be able to place the "Click me" button where ever you want without breaking the popup position.

Ex: 

`
<DateRangePicker
    ...
    backdropStyle={styles.datePickerBackdropStyle}
    childrenContainerStyle ={styles.datePickerChildrenContainerStyle}
>
    <Text>Click Me</Text>
</ DateRangePicker>
`

`
datePickerBackdropStyle: {
    width: "100%",
    height: "100%"
},
datePickerChildrenContainerStyle: {
        position: "absolute",
        top: 0,
        left: 0
}
`